### PR TITLE
Fix: image(withTint: _) method outputs wrong image

### DIFF
--- a/Sources/UIImage+.swift
+++ b/Sources/UIImage+.swift
@@ -40,6 +40,8 @@ public extension UIImage {
             return UIImage()
         }
 
+        context.scaleBy(x: 1, y: -1)
+        context.translateBy(x: 0, y: -self.size.height)
         context.clip(to: rect, mask: cgImage)
         context.setFillColor(color.cgColor)
         context.fill(rect)


### PR DESCRIPTION
image(withTint: _) method outputs upside down image ().This is the example of the `S` image.
![image](https://user-images.githubusercontent.com/16917697/35472329-963b61ca-03b0-11e8-918d-def533924f20.png)

fixed: 
![image](https://user-images.githubusercontent.com/16917697/35472361-0f9625b4-03b1-11e8-809a-4dc7581a01f2.png)
