### PR TITLE
Update Dictionary+.swift

### DIFF
--- a/Sources/Dictionary+.swift
+++ b/Sources/Dictionary+.swift
@@ -18,3 +18,16 @@ public extension Dictionary {
         return value
     }
 }
+
+public exension Dictionary {
+    public init<KS: Sequence, VS: Sequence>(
+        keys: KS, 
+        values: VS
+    ) where KS.Element == Key, VS.Element == Value
+    {
+        self = [:]
+        for (key, value) in zip(keys, valurs) {
+            self[key] = valur
+        }
+    }
+}


### PR DESCRIPTION
Allows dictionary to be created of two sequences of keys and values. The sequences do not have to be the same length. The sequences must be ordered.

Usage:

```swift
var dict: [String:Any] = Dictionary(keys: myArray, values: myNSArray)
```