### PR TITLE
Create Formatted.swift

### DIFF
--- a/Source/Formatted.swift
+++ b/Source/Formatted.swift
@@ -1,0 +1,45 @@
+public struct AttributedString: CustomStringConvertible {
+  var string: String
+  public init(_ src: String) {
+    self.string = src
+  }
+  public mutating func format<R: RangeExpression>(_ range: R, with newFormat: String) {
+    let temp = string[range]
+    string.replaceSubrange(range, with: newFormat.replacingOccurences(of: "%s", with: temp))
+  }
+  
+  public var description: String { return string }
+}
+
+public enum FormatTag: String {
+  case string = "%s"
+  case number = "%n"
+  case date = "%d"
+  case url = "%u"
+  case debug = "%r"
+}
+
+public protocol CustomFormatible {
+  public func formatedDescription(using tag: FormatTag?) -> String
+}
+
+public func _getFormatted<T>(value: , tag: FormatTag?T) -> String {
+  if let value = value as? CustomFormatible {
+    return value.formattedDescription(using: tag)
+  } else {
+    return String(describing: value)
+  }
+}
+
+public extension String {
+  public mutating func format<T>(with value: T) {
+    var scanner = StringScanner(forScanning: self)
+    let range = scanner.getRange(start: "{", end: "}")
+    replaceSubrange(range, with: FormatTag(rawValue: self[range])
+  }
+  public func formatted<T>(with value: T) -> String {
+    var copy = self
+    copy.format(with: value)
+    return copy
+  }
+}


### PR DESCRIPTION
## WARNING: This uses a type called `StringScanner` which does not exists yet but will get its own pull request, so do not merge these yet.

This is a quick way to format strings:

```swift
extension MyStruct: CustomFormatible {
  func formatedDescription(using tag: FormatTag?) -> String {
    return myCustomFormattedDescription
  }
}

var string = "{%d} + {%n}"
string.format(with: Date())
string.format(with: 2)
// string == "(Date's custom formatted) + (Int's custom formatted)"

var attributed = AttributedString("Hello, world!")
attributed.format(attributed.description.startIndex..., with: "**%s**") // bold text in Markdown
```