### PR TITLE
Create SafePointer.swift

### DIFF
--- a/Sources/SafePointer.swift
+++ b/Sources/SafePointer.swift
@@ -1,0 +1,118 @@
+import Foundation
+
+public enum SafePointerConstants {
+    public static var capacityReductionOffset = 5
+}
+
+public final class SafePointer<Element>: Sequence, Collection, MutableCollection, BidirectionalCollection, RangeReplaceableCollection, RandomAccessCollection {
+    var ptr: UnsafeMutablePointer<Element>
+    public internal(set) var capacity: Int {
+        didSet {
+            ptr = realloc(UnsafeMutableRawPointer(ptr), capacity).assumingMemoryBound(to: Element.self)
+        }
+    }
+    public internal(set) var count: Int {
+        didSet {
+            if count < 0 {
+                fatalError("Could not remove elemnt from empty pointer")
+            }
+        }
+    }
+    public init(count: Int, capacity: Int) {
+        precondition(count <= capacity)
+        self.count = count
+        self.capacity = capacity
+        self.ptr = UnsafeMutablePointer.allocate(capacity: capacity)
+    }
+    public convenience init() {
+        self.init(count: 0, capacity: 0)
+    }
+    
+    func setTop(to value: Element) {
+        ptr.advanced(by: count - 1).initialize(to: value)
+    }
+    func getTop() -> Element {
+        return ptr.advanced(by: count - 1).pointee
+    }
+    func lowerTop() {
+        count -= 1
+        if count + SafePointerConstants.capacityReductionOffset <= capacity {
+            capacity = count
+        }
+    }
+    
+    public func _increaseCapacity(_ newCapacity: Int) {
+        self.capacity = newCapacity
+    }
+    public func _grow(by dsize: Int) {
+        count += dsize
+        let result = dsize + capacity
+        _increaseCapacity(result)
+    }
+    public func append(_ newElement: Element) {
+        _grow(by: 1)
+        setTop(to: newElement)
+    }
+    public func removeLast() -> Element {
+        let current = getTop()
+        lowerTop()
+        return current
+    }
+    
+    public subscript(stride: Int) -> Element {
+        get {
+            precondition(stride >= 0 && stride < count, "Index out of bounds")
+            return ptr.advanced(by: stride).pointee
+        }
+        set {
+            precondition(stride >= 0 && stride < count, "Index out of bounds")
+            ptr.advanced(by: stride).initialize(to: newValue)
+        }
+    }
+    
+    deinit {
+        ptr.deinitialize(count: capacity)
+        ptr.deallocate()
+    }
+}
+
+public extension SafePointer {
+    public struct Iterator: IteratorProtocol {
+        let _base: SafePointer
+        var _offset, _inset: Int
+        init(_base: SafePointer, _bounds: (Int, Int)) {
+            precondition(_bounds.0 <= _bounds.1)
+            self._base = _base
+            self._offset = _bounds.0
+            self._inset = _bounds.1
+            self._index = _bounds.0
+        }
+        var _index = 0
+        public mutating func next() -> Element? {
+            if _index + 1 < (_base.count - _inset) {
+                let temp = _index
+                _index += 1
+                return _base[temp]
+            }
+            return nil
+        }
+    }
+    public func makeIterator() -> SafePointer<Element>.Iterator {
+        return Iterator(_base: self, _bounds: (0, count))
+    }
+    public func makeIterator(forBounds bounds: Indices) -> SafePointer<Element>.Iterator {
+        return Iterator(_base: self, _bounds: (bounds.lowerBound, bounds.upperBound))
+    }
+}
+
+public extension SafePointer {
+    public var startIndex: Int {
+        return 0
+    }
+    public var endIndex: Int {
+        return count
+    }
+    public func reserveCapacity(_ n: Int) {
+        self.capacity += n
+    }
+}


### PR DESCRIPTION
### Overview

It is very difficult for a beginner to understand memory in Swift and how to manage with it effectively. This PR attempts to fix the problem with a new type, `SafePointer`.

### Examples:

```swift
// Allocates a new pointer with the contents of a sequence
var pointer = SafePointer([1, 2, 3, 4, 5, 6]) // pointer.capacity == 9
pointer.append(5) // pointer.capacity == 10

// Normal collection applies
pointer.removeLast(4) // pointer.capacity == 4
for element in pointer.dropFirst(2).map({ $0 * 2 }) {
    print(element)
}
```

The growth for capacity is eager to increase, which is why it has space for more elements than it needs.